### PR TITLE
default property

### DIFF
--- a/src/Annotation/AbstractWebContextParam.php
+++ b/src/Annotation/AbstractWebContextParam.php
@@ -24,4 +24,9 @@ abstract class AbstractWebContextParam
      * @var string
      */
     public $param;
+
+    /**
+     * @var string
+     */
+    public $default;
 }

--- a/src/WebContextParamInterceptor.php
+++ b/src/WebContextParamInterceptor.php
@@ -71,28 +71,11 @@ class WebContextParamInterceptor implements MethodInterceptor
         foreach ($annotations as $annotation) {
             if ($annotation instanceof AbstractWebContextParam) {
                 $pos = $this->getPos($annotation, $method);
-                $meta[$pos] = [$annotation::GLOBAL_KEY, $annotation->key];
+                $meta[$pos] = [$annotation::GLOBAL_KEY, $annotation->key, $annotation->default];
             }
         }
 
         return $meta;
-    }
-
-    /**
-     * @param array $meta
-     * @param int   $i
-     *
-     * @return array
-     */
-    private function getParam(array $meta, $i)
-    {
-        list($globalKey, $key) = $meta[$i];
-        $webContext = $this->webContext->get($globalKey);
-        if (isset($webContext[$key])) {
-            return [true, $webContext[$key]];
-        }
-
-        return [false, null];
     }
 
     /**
@@ -124,10 +107,30 @@ class WebContextParamInterceptor implements MethodInterceptor
     private function setArg(Arguments $args, array $meta, $i)
     {
         if (isset($meta[$i]) && (! isset($args[$i]))) {
-            list($hasParam, $param) = $this->getParam($meta, $i);
+            list($hasParam, $param, $default) = $this->getParam($meta, $i);
             if ($hasParam) {
                 $args[$i] = $param;
             }
+            if ($default) {
+                $args[$i] = $default;
+            }
         }
+    }
+
+    /**
+     * @param array $meta
+     * @param int   $i
+     *
+     * @return array
+     */
+    private function getParam(array $meta, $i)
+    {
+        list($globalKey, $key, $default) = $meta[$i];
+        $webContext = $this->webContext->get($globalKey);
+        if (isset($webContext[$key])) {
+            return [true, $webContext[$key], $default];
+        }
+
+        return [false, null, $default];
     }
 }

--- a/src/WebContextParamModule.php
+++ b/src/WebContextParamModule.php
@@ -38,5 +38,6 @@ class WebContextParamModule extends AbstractModule
         );
         $this->bind(Reader::class)->to(AnnotationReader::class)->in(Scope::SINGLETON);
         $this->bind(Cache::class)->to(ArrayCache::class)->in(Scope::SINGLETON);
+        $this->bind(WebContext::class);
     }
 }

--- a/tests/Fake/FakeConsumer.php
+++ b/tests/Fake/FakeConsumer.php
@@ -34,4 +34,12 @@ class FakeConsumer
     {
         $this->id = $id;
     }
+
+    /**
+     * @QueryParam(key="id", param="id", default="_deffault_by_interceptor_")
+     */
+    public function useDefault($id)
+    {
+        $this->id = $id;
+    }
 }

--- a/tests/WebParamInjectInterceptorTest.php
+++ b/tests/WebParamInjectInterceptorTest.php
@@ -78,6 +78,15 @@ class WebParamInjectInterceptorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $obj->id);
     }
 
+    public function testDefaultProperty()
+    {
+        $obj = new FakeConsumer;
+        $invocation = $this->factory($obj, 'useDefault', [], new QueryParam, []);
+        $invocation->proceed();
+        $expected = '_deffault_by_interceptor_';
+        $this->assertSame($expected, $obj->id);
+    }
+
     public function testCookieParam()
     {
         $this->assertSame('_COOKIE', CookieParam::GLOBAL_KEY);


### PR DESCRIPTION
When the parameter is not given by function call nor web text,
`default` property in annotation is used.
